### PR TITLE
Remove Wacom Windows Update Helper App Service

### DIFF
--- a/config/driver_identifiers.json
+++ b/config/driver_identifiers.json
@@ -192,6 +192,12 @@
     "class": "745a17a0-74d3-11d0-b6fe-00a0c90f57da"
   },
   {
+    "friendly_name": "Wacom Windows Update Helper App Service",
+    "original_name": "wacomwuhaservicecom\\.inf",
+    "provider": "Wacom Technology",
+    "class": "5c4c3332-344d-483c-8739-259e934c9cc8"
+  },
+  {
     "friendly_name": "Wacom WUSD",
     "original_name": "wacom_wusd\\.inf",
     "provider": "Wacom Technology",


### PR DESCRIPTION
Fixes https://github.com/X9VoiD/TabletDriverCleanup/issues/19

Ref on what WUHA stands for by wacom support: https://support.wacom.com/hc/en-us/community/posts/28368470296471/comments/35553103257751

"For users that have no driver installed, plugging in a tablet can trigger Windows Update to provide our Wacom WUHA Service.  (Windows Update Helper App)"

```json
{
  "inf_name": "oem57.inf",
  "inf_original_name": "wacomwuhaservicecom.inf",
  "driver_store_location": "C:\\Windows\\System32\\DriverStore\\FileRepository\\wacomwuhaservicecom.inf_amd64_8d082370362a6ce9",
  "provider": "Wacom Technology",
  "class": "SoftwareComponent",
  "class_guid": "5c4c3332-344d-483c-8739-259e934c9cc8"
}
```