### PR TITLE
Add generic libusbk driver check

### DIFF
--- a/config/driver_identifiers.json
+++ b/config/driver_identifiers.json
@@ -22,6 +22,11 @@
     "class": "4d36e978-e325-11ce-bfc1-08002be10318"
   },
   {
+    "friendly_name": "Generic LibUsbK Driver",
+    "original_name": "tablet[ _]monitor[ _]\\([Ii]nterface[ _]\\d+\\)\\.inf",
+    "provider": "(libusbK|libusb-win32)"
+  },
+  {
     "friendly_name": "Hanvon Ugee Mouse Filter",
     "original_name": "hanvonugeemfilter\\.inf",
     "provider": "Hanvon Ugee Technology",


### PR DESCRIPTION
Fixes the other part of https://github.com/X9VoiD/TabletDriverCleanup/issues/21

```json
  {
    "inf_name": "oem101.inf",
    "inf_original_name": "tablet_monitor_(interface_0).inf",
    "driver_store_location": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\tablet_monitor_(interface_0).inf_amd64_4651141c0e79ec35",
    "provider": "libusb-win32",
    "class": "libusb-win32 devices",
    "class_guid": "eb781aaf-9c70-4523-a5df-642a87eca567"
  },
  {
    "inf_name": "oem11.inf",
    "inf_original_name": "tablet_monitor_(interface_0).inf",
    "driver_store_location": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\tablet_monitor_(interface_0).inf_amd64_79d7c796b835a452",
    "provider": "libusbK",
    "class": "libusbk devices",
    "class_guid": "ecfb0cfd-74c4-4f52-bbf7-343461cd72ac"
  },
  {
    "inf_name": "oem71.inf",
    "inf_original_name": "tablet_monitor_(interface_0).inf",
    "driver_store_location": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\tablet_monitor_(interface_0).inf_amd64_c1567e0d64b55566",
    "provider": "libusb-win32",
    "class": "libusb-win32 devices",
    "class_guid": "eb781aaf-9c70-4523-a5df-642a87eca567"
  },
  {
    "inf_name": "oem85.inf",
    "inf_original_name": "tablet_monitor_(interface_0).inf",
    "driver_store_location": "C:\\WINDOWS\\System32\\DriverStore\\FileRepository\\tablet_monitor_(interface_0).inf_amd64_1cb0ac8989166b7c",
    "provider": "libusb-win32",
    "class": "libusb-win32 devices",
    "class_guid": "eb781aaf-9c70-4523-a5df-642a87eca567"
  }
```